### PR TITLE
replace hiredis to hiredis-client

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,10 +14,10 @@ gem 'addressable'
 gem 'sidekiq'
 gem 'sidekiq-bulk'
 gem 'dotenv-rails'
-gem 'hiredis', '~> 0.6'
 gem 'nokogiri'
+gem "hiredis-client", "~> 0.18.0"
 gem 'redis-namespace', '~> 1.10'
-gem 'redis', '~> 5.0', require: ['redis', 'redis/connection/hiredis']
+gem 'redis', '~> 5.0'
 gem 'redis-rails'
 gem 'fast_blank'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,7 +107,8 @@ GEM
       ruby-progressbar (~> 1.4)
     globalid (1.2.1)
       activesupport (>= 6.1)
-    hiredis (0.6.3)
+    hiredis-client (0.18.0)
+      redis-client (= 0.18.0)
     http (5.1.1)
       addressable (~> 2.8)
       http-cookie (~> 1.0)
@@ -300,7 +301,7 @@ DEPENDENCIES
   dotenv-rails
   fast_blank
   fuubar
-  hiredis (~> 0.6)
+  hiredis-client (~> 0.18.0)
   http
   listen (>= 3.0.5, < 3.9)
   lograge
@@ -326,4 +327,4 @@ RUBY VERSION
    ruby 3.2.2p53
 
 BUNDLED WITH
-   2.1.4
+   2.4.22


### PR DESCRIPTION
After updating to redis v5.x, I was unable to start with the error "LoadError: cannot load such file -- redis/connection/hiredis".
Starting with redis v5.x, it seems that you need the hiredis-client gem instead of hiredis.