### PR TITLE
Introduce DevContainer for development

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,7 @@
+ARG RUBY_VERSION=3.3.1
+FROM docker.io/library/ruby:$RUBY_VERSION-slim
+
+WORKDIR /app
+
+RUN apt-get update -qq && \
+    apt-get install -y curl git ruby autoconf gcc make zlib1g-dev libffi-dev libreadline-dev libgdbm-dev libssl-dev libyaml-dev libjemalloc2 libpq-dev

--- a/.devcontainer/compose.yml
+++ b/.devcontainer/compose.yml
@@ -1,0 +1,54 @@
+services:
+  app:
+    working_dir: /workspaces/activity-pub-relay/
+    build:
+      context: ..
+      dockerfile: .devcontainer/Dockerfile
+    volumes:
+      - ..:/workspaces/pub-relay-prototype:cached
+    environment:
+      RAILS_ENV: development
+      BINDING: 0.0.0.0
+      REDIS_HOST: redis
+      REDIS_PORT: '6379'
+      REDIS_URL: "redis:6379/1"
+      DB_HOST: db
+      DB_USER: postgres
+      DB_PASS: postgres
+      DB_PORT: '5432'
+    command: sleep infinity
+    ports:
+      - '3000:3000'
+    networks:
+      - external_network
+      - internal_network
+
+  db:
+    image: postgres:14-alpine
+    restart: unless-stopped
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_DB: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_HOST_AUTH_METHOD: trust
+    networks:
+      - internal_network
+
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    volumes:
+      - redis-data:/data
+    networks:
+      - internal_network
+
+volumes:
+  postgres-data:
+  redis-data:
+
+networks:
+  external_network:
+  internal_network:
+    internal: true

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,9 @@
+{
+  "name": "ActivityPub Relay development container",
+  "dockerComposeFile": "compose.yml",
+  "service": "app",
+  "forwardPorts": [3000],
+  "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+  "remoteUser": "root",
+  "postCreateCommand": "bin/setup --skip-server",
+}


### PR DESCRIPTION
## やったこと

開発環境向けにDevContainerを導入しています。

## 背景

背景としては
- RailsやRubyのアップデート対応がしやすくなるようにしたい
- そのためにはテストが追加されているとよさそう
- テストを実行するためにRedisやPostgreSQLを立ち上げるのは大変そう
- DevContainerで開発環境がセットアップできるようにしたい
という感じです。

そのため今後のテスト追加やRubyとRailsのアップデート対応を進めるために必要なのでこちらを先にマージできると嬉しいです。

## 動作確認方法など

RedisやPostgreSQLなどもコンテナ内で別途立ち上げたものを開発環境で使用するようにしてあるので、DockerとVS Code(DevContainerのプラグインが必要)があれば開発環境がセットアップできると思います。
また念のためにDevContainerのCLI経由でVimからDevContainerが利用できることは確認してあります。
