### PR TITLE
Fix Github Actions CI target to use for-taruntarun instead of main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   pull_request:
   push:
-    branches: [ main ]
+    branches: [ for-taruntarun ]
 
 jobs:
   test:


### PR DESCRIPTION
## やったこと

#587 で追加したGitHub Actionsのターゲットブランチの変更

## 内容

#587 ではmainブランチを対象にCIが動くようにしていました。
そのためマージ後のCIが動いていないようなのでターゲットのブランチをfor-taruntarunに変更してあります。