### PR TITLE
Add/test for pub relay prototype

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
           DB_USER: postgres
           DB_PASS: postgres
           REDIS_URL: redis://localhost:6379/0
+          DOMAIN: example.com
 
         run: |
           bin/rails db:test:prepare

--- a/spec/controllers/actors_controller_spec.rb
+++ b/spec/controllers/actors_controller_spec.rb
@@ -1,7 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe ActorsController, :type => :controller do
-  describe 'GET #show' do
-    pending
-  end
-end

--- a/spec/controllers/inboxes_controller_spec.rb
+++ b/spec/controllers/inboxes_controller_spec.rb
@@ -1,7 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe InboxesController, :type => :controller do
-  describe 'POST #create' do
-    pending
-  end
-end

--- a/spec/controllers/webfinger_controller_spec.rb
+++ b/spec/controllers/webfinger_controller_spec.rb
@@ -1,7 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe WebfingerController, :type => :controller do
-  describe 'GET #show' do
-    pending
-  end
-end

--- a/spec/models/actor_spec.rb
+++ b/spec/models/actor_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+RSpec.describe Actor, type: :model do
+  describe ".key" do
+    let(:path) { Rails.root.join("config/actor.pem") }
+
+    it "should return public key pem" do
+      expected_public_key_pem = OpenSSL::PKey::RSA.new(path.read).public_key.to_pem
+
+      expect(expected_public_key_pem).to eq Actor.key.public_key.to_pem
+    end
+  end
+end

--- a/spec/requests/inboxes_spec.rb
+++ b/spec/requests/inboxes_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+RSpec.describe '/inbox', type: :request do
+  describe 'POST /inbox' do
+    context 'when not signed_request_account' do
+      before do
+        allow_any_instance_of(InboxesController).to receive(:signed_request_account).and_return(false)
+      end
+
+      it 'should return 401' do
+        post '/inbox'
+
+        expect(response).to have_http_status 401
+      end
+    end
+
+    context 'when signed_request' do
+      context 'when blocked domain' do
+        before do
+          allow_any_instance_of(InboxesController).to receive(:signed_request_account).and_return(true)
+          allow_any_instance_of(InboxesController).to receive(:blocked?).and_return(true)
+        end
+
+        it 'should return 401' do
+          post '/inbox'
+
+          expect(response).to have_http_status 401
+        end
+      end
+
+      context 'when not blocked domain' do
+        before do
+          allow_any_instance_of(InboxesController).to receive(:signed_request_account).and_return(true)
+          allow_any_instance_of(InboxesController).to receive(:blocked?).and_return(false)
+        end
+
+        it 'should return 202' do
+          post '/inbox'
+
+          expect(response).to have_http_status 202
+        end
+
+        it 'should enqueued ProcessWorker' do
+          expect(ProcessWorker).to receive(:perform_async)
+
+          post '/inbox'
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/root_spec.rb
+++ b/spec/requests/root_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe '/', type: :request do
+  it 'should return 200' do
+    get '/'
+
+    expect(response).to have_http_status 200
+  end
+
+  it 'should response include /inbox path' do
+    get '/'
+
+    expect(response.body).to include('/inbox')
+  end
+end

--- a/spec/requests/webfinger_spec.rb
+++ b/spec/requests/webfinger_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe '/.well-known/webfinger', type: :request do
+  context "when params[:resource] is blank" do
+    it 'should return 404' do
+      get '/.well-known/webfinger'
+
+      expect(response).to have_http_status 404
+    end
+  end
+
+  context "when params[:resource] is wrong" do
+    it "should return 404" do
+      get '/.well-known/webfinger?resource=acct:wrong@example.com'
+
+      expect(response).to have_http_status 404
+    end
+  end
+
+  context "when params[:resource] is present" do
+    it 'should return 200' do
+      get '/.well-known/webfinger?resource=acct:relay@example.com'
+
+      expect(response).to have_http_status 200
+    end
+  end
+end

--- a/spec/workers/process_worker_spec.rb
+++ b/spec/workers/process_worker_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe ProcessWorker, :type => :job do
 
   subject { described_class.new }
 
-  skip 'with follow activity' do
+  context 'with follow activity' do
     let(:body) do
       Oj.dump({
         '@context': 'https://www.w3.org/ns/activitystreams',
@@ -26,14 +26,14 @@ RSpec.describe ProcessWorker, :type => :job do
     end
 
     it 'creates subscription' do
-      subscription = Subscription.find_by(account_id: actor['id'])
+      subscription = Subscription.find_by(domain: 'example.com')
 
       expect(subscription).to_not be_nil
       expect(subscription.inbox_url).to eq actor['inbox']
     end
   end
 
-  skip 'with unfollow activity' do
+  context 'with unfollow activity' do
     let(:body) do
       Oj.dump({
         '@context': 'https://www.w3.org/ns/activitystreams',
@@ -50,18 +50,18 @@ RSpec.describe ProcessWorker, :type => :job do
     end
 
     before do
-      Subscription.create!(account_id: actor['id'], inbox_url: actor['inbox'])
+      Subscription.create!(domain: 'example.com', inbox_url: actor['inbox'])
       subject.perform(actor, body)
     end
 
     it 'removes subscription' do
-      subscription = Subscription.find_by(account_id: actor['id'])
+      subscription = Subscription.find_by(domain: actor['id'])
       expect(subscription).to be_nil
     end
   end
 
-  skip 'with generic activity' do
-    let!(:subscription) { Subscription.create(account_id: 'https://subscriber-example.com/actor', inbox_url: 'https://subscriber-example.com/inbox') }
+  context 'with generic activity' do
+    let!(:subscription) { Subscription.create(domain: 'https://subscriber-example.com/actor', inbox_url: 'https://subscriber-example.com/inbox') }
 
     let(:body) do
       Oj.dump({


### PR DESCRIPTION
## 概要

利用されていないテストケースの削除と簡単なテストケースの追加になります

## やったこと

利用されていない古いテストケースに関しては推奨されていないcontroller specだったので削除しています。
またモックを使った簡単なテストケースを追加しています。

具体的には
- request specに関しては /actor以外のエンドポイントを追加
  - /inbox だけ実際のリクエストの内容を用意するのが大変なのでモックで対応
- Actorモデルのkeyのチェックを追加
- スキップしていたProcessWorkerのテストをパスするように修正

となります。
